### PR TITLE
Enable automatic GitHub Pages setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow to automatically enable the Pages site when deploying

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4eba904708329a12fb739ab63f5a2