### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Der Befehl `npm run build` erstellt ein produktionsfertiges Bundle im Ordner `di
 
 ## GitHub Pages Deployment
 
-1. Aktivieren Sie GitHub Pages für dieses Repository unter **Settings → Pages** und wählen Sie `GitHub Actions` als Quelle.
+1. Aktivieren Sie GitHub Pages für dieses Repository unter **Settings → Pages** und wählen Sie `GitHub Actions` als Quelle (dieser Schritt muss einmalig manuell erfolgen, da der Workflow keine Admin-Rechte besitzt).
 2. Pushen Sie den Code auf GitHub – der Workflow `.github/workflows/deploy.yml` baut das Projekt und veröffentlicht es auf dem `gh-pages`-Branch.
 3. Die Seite ist anschließend unter `https://<ihr-user>.github.io/wasm-nt/` erreichbar.
 


### PR DESCRIPTION
## Summary
- stop requesting GitHub Pages enablement from the workflow to avoid permission errors
- document that Pages must be enabled manually once before the workflow can deploy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ecd018c08329afd2262ec5bf976f